### PR TITLE
Fix include style part 2: rearrange headers

### DIFF
--- a/maliput_py/src/bindings/api_py.cc
+++ b/maliput_py/src/bindings/api_py.cc
@@ -1,11 +1,10 @@
-#include <pybind11/pybind11.h>
-
 #include <maliput/api/junction.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/api/road_network.h>
 #include <maliput/api/segment.h>
+#include <pybind11/pybind11.h>
 
 namespace maliput {
 namespace bindings {

--- a/maliput_py/src/bindings/math_py.cc
+++ b/maliput_py/src/bindings/math_py.cc
@@ -1,8 +1,7 @@
-#include <pybind11/pybind11.h>
-
 #include <maliput/math/quaternion.h>
 #include <maliput/math/roll_pitch_yaw.h>
 #include <maliput/math/vector.h>
+#include <pybind11/pybind11.h>
 
 namespace maliput {
 namespace bindings {

--- a/maliput_py/src/bindings/plugin_py.cc
+++ b/maliput_py/src/bindings/plugin_py.cc
@@ -1,13 +1,12 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <map>
+#include <string>
 
 #include <maliput/common/logger.h>
 #include <maliput/plugin/maliput_plugin.h>
 #include <maliput/plugin/maliput_plugin_manager.h>
 #include <maliput/plugin/road_network_loader.h>
-
-#include <map>
-#include <string>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace maliput {
 namespace bindings {


### PR DESCRIPTION
Prepare for the 20.04 version of clang-format. Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196