### PR TITLE
rosdep update --include-eol-distros

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build
       shell: bash

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -74,7 +74,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -59,7 +59,7 @@ jobs:
       shell: bash
       working-directory: ${{ env.ROS_WS }}
       run: |
-        rosdep update;
+        rosdep update --include-eol-distros;
         rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
     - name: colcon build up-to
       shell: bash


### PR DESCRIPTION
`dashing` is now end-of-life so we should use `--include-eol-distros` with `rosdep update`

See https://github.com/ToyotaResearchInstitute/maliput/pull/425

Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196