### PR TITLE
Adds MaliputPluginManager::ListPlugins binding.

### DIFF
--- a/maliput_py/src/bindings/maliput_python_interface.h
+++ b/maliput_py/src/bindings/maliput_python_interface.h
@@ -62,6 +62,9 @@
 /// import maliput.plugin
 ///
 /// manager = maliput.plugin.MaliputPluginManager()
+/// # Plugins` id can be listed by doing:
+/// plugin_ids = maliput.plugin.MaliputPluginManager().ListPlugins()
+/// # A loaded plugin can be obtained by doing:
 /// my_plugin = maliput.plugin.MaliputPluginManager().GetPlugin("foo_plugin")
 /// @endcode
 ///

--- a/maliput_py/src/bindings/plugin_py.cc
+++ b/maliput_py/src/bindings/plugin_py.cc
@@ -1,5 +1,7 @@
+#include <algorithm>
 #include <map>
 #include <string>
+#include <vector>
 
 #include <maliput/common/logger.h>
 #include <maliput/plugin/maliput_plugin.h>
@@ -59,7 +61,14 @@ PYBIND11_MODULE(plugin, m) {
            [](plugin::MaliputPluginManager& self, const std::string& plugin_name) {
              return self.GetPlugin(plugin::MaliputPlugin::Id(plugin_name));
            })
-      .def("AddPlugin", &plugin::MaliputPluginManager::AddPlugin);
+      .def("AddPlugin", &plugin::MaliputPluginManager::AddPlugin)
+      .def("ListPlugins", [](plugin::MaliputPluginManager& self) {
+        const auto plugins = self.ListPlugins();
+        std::vector<std::string> plugins_str{};
+        std::transform(plugins.begin(), plugins.end(), std::back_inserter(plugins_str),
+                       [](const plugin::MaliputPlugin::Id& id) { return id.string(); });
+        return plugins_str;
+      });
 
   m.def("create_road_network_from_plugin", &CreateRoadNetworkFromPlugin,
         "Creates a maliput::api::plugin::RoadNetwork using `plugin_id` implementation.", py::arg("plugin_id"),


### PR DESCRIPTION
Depends on https://github.com/ToyotaResearchInstitute/maliput/pull/445
Related to https://github.com/ToyotaResearchInstitute/maliput_py/issues/21

```py

>>> import maliput.plugin
>>> manager = maliput.plugin.MaliputPluginManager()
>>> manager.ListPlugins()
['maliput_dragway', 'maliput_malidrive', 'maliput_multilane']

```