### PR TITLE
Extends LanePosition and ***Id python interface

### DIFF
--- a/maliput_py/src/bindings/api_py.cc
+++ b/maliput_py/src/bindings/api_py.cc
@@ -101,7 +101,8 @@ PYBIND11_MODULE(api, m) {
 
   py::class_<api::JunctionId>(m, "JunctionId")
       .def(py::init<std::string>())
-      .def("string", &api::JunctionId::string, py::return_value_policy::reference_internal);
+      .def("string", &api::JunctionId::string, py::return_value_policy::reference_internal)
+      .def("__repr__", [](const api::JunctionId& id) { return id.string(); });
 
   py::class_<api::Junction>(m, "Junction")
       .def("num_segments", &api::Junction::num_segments)
@@ -111,7 +112,8 @@ PYBIND11_MODULE(api, m) {
 
   py::class_<api::SegmentId>(m, "SegmentId")
       .def(py::init<std::string>())
-      .def("string", &api::SegmentId::string, py::return_value_policy::reference_internal);
+      .def("string", &api::SegmentId::string, py::return_value_policy::reference_internal)
+      .def("__repr__", [](const api::SegmentId& id) { return id.string(); });
 
   py::class_<api::Segment>(m, "Segment")
       .def("num_lanes", &api::Segment::num_lanes)
@@ -121,7 +123,8 @@ PYBIND11_MODULE(api, m) {
 
   py::class_<api::LaneId>(m, "LaneId")
       .def(py::init<std::string>())
-      .def("string", &api::LaneId::string, py::return_value_policy::reference_internal);
+      .def("string", &api::LaneId::string, py::return_value_policy::reference_internal)
+      .def("__repr__", [](const api::LaneId& id) { return id.string(); });
 
   py::class_<api::Lane>(m, "Lane")
       .def("ToLanePosition", &api::Lane::ToLanePosition)

--- a/maliput_py/test/api/api_test.py
+++ b/maliput_py/test/api/api_test.py
@@ -121,6 +121,7 @@ class TestMaliputApi(unittest.TestCase):
         """
         dut = LaneId("dut")
         self.assertEqual("dut", dut.string())
+        self.assertEqual("dut", dut.__repr__())
 
     def test_segment_id(self):
         """
@@ -128,6 +129,7 @@ class TestMaliputApi(unittest.TestCase):
         """
         dut = SegmentId("dut")
         self.assertEqual("dut", dut.string())
+        self.assertEqual("dut", dut.__repr__())
 
     def test_junction_id(self):
         """
@@ -135,3 +137,4 @@ class TestMaliputApi(unittest.TestCase):
         """
         dut = JunctionId("dut")
         self.assertEqual("dut", dut.string())
+        self.assertEqual("dut", dut.__repr__())


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/maliput_py/issues/21

Solves 
> - [ ] LanePosition has no s(), r(), h(). It has to be accessed through an x,y,z of a vector. This is not logical. We need to expose s(), r(), h()
> - [ ] IDs don't have automatic string conversion. even str() over the ID methods doesn't resolve. (I see now they have .string(), i wonder if we can make that implicit with repr
