### PR TITLE
Adds bindings for new GetState method in the state providers.

### DIFF
--- a/maliput_py/src/bindings/api_rules_py.cc
+++ b/maliput_py/src/bindings/api_rules_py.cc
@@ -208,8 +208,15 @@ void InitializeRulesNamespace(py::module* m) {
       .def_readwrite("discrete_value_rules", &rules::RoadRulebook::QueryResults::discrete_value_rules)
       .def_readwrite("range_value_rules", &rules::RoadRulebook::QueryResults::range_value_rules);
 
-  auto dvr_state_provider_type = py::class_<rules::DiscreteValueRuleStateProvider>(*m, "DiscreteValueRuleStateProvider")
-                                     .def("GetState", &rules::DiscreteValueRuleStateProvider::GetState, py::arg("id"));
+  auto dvr_state_provider_type =
+      py::class_<rules::DiscreteValueRuleStateProvider>(*m, "DiscreteValueRuleStateProvider")
+          .def("GetState",
+               py::overload_cast<const rules::Rule::Id&>(&rules::DiscreteValueRuleStateProvider::GetState, py::const_),
+               py::arg("id"))
+          .def("GetState",
+               py::overload_cast<const RoadPosition&, const rules::Rule::TypeId&, double>(
+                   &rules::DiscreteValueRuleStateProvider::GetState, py::const_),
+               py::arg("road_position"), py::arg("rule_type"), py::arg("tolerance"));
 
   auto dvr_state_provider_state_result_type =
       py::class_<rules::DiscreteValueRuleStateProvider::StateResult>(dvr_state_provider_type, "StateResult")
@@ -220,8 +227,15 @@ void InitializeRulesNamespace(py::module* m) {
       .def_readwrite("state", &rules::DiscreteValueRuleStateProvider::StateResult::Next::state)
       .def_readwrite("duration_until", &rules::DiscreteValueRuleStateProvider::StateResult::Next::duration_until);
 
-  auto rvr_state_provider_type = py::class_<rules::RangeValueRuleStateProvider>(*m, "RangeValueRuleStateProvider")
-                                     .def("GetState", &rules::RangeValueRuleStateProvider::GetState, py::arg("id"));
+  auto rvr_state_provider_type =
+      py::class_<rules::RangeValueRuleStateProvider>(*m, "RangeValueRuleStateProvider")
+          .def("GetState",
+               py::overload_cast<const rules::Rule::Id&>(&rules::RangeValueRuleStateProvider::GetState, py::const_),
+               py::arg("id"))
+          .def("GetState",
+               py::overload_cast<const RoadPosition&, const rules::Rule::TypeId&, double>(
+                   &rules::RangeValueRuleStateProvider::GetState, py::const_),
+               py::arg("road_position"), py::arg("rule_type"), py::arg("tolerance"));
 
   auto rvr_state_provider_state_result_type =
       py::class_<rules::RangeValueRuleStateProvider::StateResult>(rvr_state_provider_type, "StateResult")


### PR DESCRIPTION
Related to https://github.com/ToyotaResearchInstitute/maliput/issues/458
Depends on https://github.com/ToyotaResearchInstitute/maliput/pull/473
### Summary

As the title says, it adds bindings for the new GetState methods that are part of :
 - maliput::api::rules::DiscreteValueRuleStateProvider
 - maliput::api::rules::RangeValueRuleStateProvider
 
 So it can be used like:
```py
road_position = maliput.api.RoadPosition(lane, maliput.api.LanePosition(0., 0., 0.))
rule_type = maliput.api.rules.Rule.TypeId("Direction-Usage Rule Type");
state_result = road_network.discrete_value_rule_state_provider().GetState(road_position, rule_type, 1e-3)
print(state_result.state.value)
```

```py
road_position = maliput.api.RoadPosition(lane, maliput.api.LanePosition(0., 0., 0.))
rule_type = maliput.api.rules.Rule.TypeId("Speed-Limit Rule Type");
state_result = road_network.range_value_rule_state_provider().GetState(road_position, rule_type, 1e-3)
print(state_result.state.max)
```