### PR TITLE
Added a binding in RoadPosition for ToInertialPosition method

### DIFF
--- a/maliput_py/src/bindings/api_py.cc
+++ b/maliput_py/src/bindings/api_py.cc
@@ -68,7 +68,8 @@ PYBIND11_MODULE(api, m) {
            // Keep alive, reference: `self` keeps `Lane*` alive.
            py::keep_alive<1, 2>())
       .def_readwrite("pos", &api::RoadPosition::pos)
-      .def_readonly("lane", &api::RoadPosition::lane);
+      .def_readonly("lane", &api::RoadPosition::lane)
+      .def("ToInertialPosition", &api::RoadPosition::ToInertialPosition);
 
   py::class_<api::RoadPositionResult>(m, "RoadPositionResult")
       .def(py::init<>())

--- a/maliput_py/test/api/api_test.py
+++ b/maliput_py/test/api/api_test.py
@@ -115,6 +115,7 @@ class TestMaliputApi(unittest.TestCase):
         dut = RoadPosition()
         self.assertEqual(None, dut.lane)
         self.assertEqual(Vector3(0., 0., 0.), dut.pos.srh())
+        self.assertTrue('ToInertialPosition' in dir(RoadPosition))
 
     def test_empty_road_position_result(self):
         """


### PR DESCRIPTION
This PR is a follow up of this [PR](https://github.com/ToyotaResearchInstitute/maliput/pull/490).

Adds the python binding for `RoadPosition::ToInertialPosition` method.