### PR TITLE
Uses ros-action-ci in build.yaml workflow.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -3,6 +3,10 @@ repositories:
     type: git
     url: https://github.com/ToyotaResearchInstitute/ament_cmake_doxygen
     version: main
+  maliput:
+    type: git
+    url: https://github.com/maliput/maliput
+    version: main
   pybind11:
     type: git
     url: https://github.com/RobotLocomotion/pybind11.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: gcc
 
 on:
+  push:
   pull_request:
     branches:
       - main
@@ -9,7 +10,6 @@ on:
 env:
   PACKAGE_NAME: maliput_py
   ROS_DISTRO: foxy
-  ROS_WS: maliput_ws
 
 jobs:
   compile_and_test:
@@ -18,87 +18,12 @@ jobs:
     container:
       image: ubuntu:20.04
     steps:
-    # setup-ros first since it installs git, which is needed to fetch all branches from actions/checkout
-    - uses: ros-tooling/setup-ros@0.2.1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: ros-tooling/setup-ros@v0.3
+    - uses: ros-tooling/action-ros-ci@v0.2
+      id: action_ros_ci_step
       with:
-        path: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}
-    # clone private dependencies
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput
-        token: ${{ secrets.MALIPUT_TOKEN }}
-    # clone public dependencies
-    - name: vcs import
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: vcs import src < src/${PACKAGE_NAME}/.github/dependencies.repos
-    - name: check if dependencies have a matching branch
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}/src
-      run: ./${PACKAGE_NAME}/.github/try_vcs_checkout ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} .
-    - run: colcon graph
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-    - name: rosdep install
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        rosdep update --include-eol-distros;
-        rosdep install  -i -y --rosdistro ${ROS_DISTRO} --skip-keys "pybind11" --from-paths src
-    # Build ament_cmake_doxygen.
-    - name: colcon build ament_cmake_doxygen
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-select ament_cmake_doxygen --event-handlers=console_direct+;
-    # Build libraries.
-    - name: colcon build libraries
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-up-to ${PACKAGE_NAME} \
-          --event-handlers=console_direct+ \
-          --cmake-args -DBUILD_TESTING=OFF -DBUILD_DOCS=OFF;
-    # Build tests for current package.
-    - name: colcon build tests
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon build --packages-select ${PACKAGE_NAME} \
-          --event-handlers=console_direct+ \
-          --cmake-args -DBUILD_TESTING=ON -DBUILD_DOCS=OFF;
-    # Test package.
-    - name: colcon test
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        colcon test --packages-select ${PACKAGE_NAME} --event-handlers=console_direct+;
-        colcon test-result --verbose;
-    # Build documentation.
-    - name: colcon build doxygen documentation
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        . install/setup.bash;
-        colcon build --packages-up-to ${PACKAGE_NAME} \
-            --event-handlers=console_direct+ \
-            --cmake-args -DBUILD_TESTING=OFF -DBUILD_DOCS=ON;
-    # Test doxygen documentation.
-    - name: colcon test doxygen documentation
-      shell: bash
-      working-directory: ${{ env.ROS_WS }}
-      run: |
-        . /opt/ros/${ROS_DISTRO}/setup.bash;
-        . install/setup.bash;
-        colcon test --packages-select ${PACKAGE_NAME} \
-            --ctest-args ' -R' ' maliput_py_doxygen_warnings' \
-            --event-handlers=console_direct+;
-        colcon test-result --verbose;
+        package-name: ${{ env.PACKAGE_NAME }}
+        target-ros2-distro: ${{ env.ROS_DISTRO }}
+        vcs-repo-file-url: ${GITHUB_WORKSPACE}/.github/dependencies.repos
+        rosdep-skip-keys: pybind11

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -41,13 +41,6 @@ jobs:
     - name: clang 8 install
       shell: bash
       run: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}/.github/clang_suite_installation.sh
-    # clone private dependencies
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput
-        token: ${{ secrets.MALIPUT_TOKEN }}
     # clone public dependencies
     - name: vcs import
       shell: bash

--- a/.github/workflows/scan_build.yml
+++ b/.github/workflows/scan_build.yml
@@ -30,13 +30,6 @@ jobs:
     - name: clang 8 install
       shell: bash
       run: ${{ env.ROS_WS }}/src/${{ env.PACKAGE_NAME }}/.github/clang_suite_installation.sh
-    # clone private dependencies
-    - uses: actions/checkout@v2
-      with:
-        repository: ToyotaResearchInstitute/maliput
-        fetch-depth: 0
-        path: ${{ env.ROS_WS }}/src/maliput
-        token: ${{ secrets.MALIPUT_TOKEN }}
     # clone public dependencies
     - name: vcs import
       shell: bash


### PR DESCRIPTION
Part of https://github.com/maliput/maliput_infrastructure/issues/268#issuecomment-1148712661


Rely on `ros-action-ci` for the `build.yaml` workflow


action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/18dfba70fefe81314bc8a68138732f53/raw/6ca6e0def9d90e93d84d7ce20ad99c437bdd0e7a/prs.repos

Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>