### PR TITLE
Fixes IntersectionBook's bug.

### DIFF
--- a/src/bindings/api_py.cc
+++ b/src/bindings/api_py.cc
@@ -348,8 +348,9 @@ PYBIND11_MODULE(api, m) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   py::class_<api::IntersectionBook>(m, "IntersectionBook")
-      .def("GetIntersections", &api::IntersectionBook::GetIntersections)
-      .def("GetIntersection", &api::IntersectionBook::GetIntersection, py::arg("id"))
+      .def("GetIntersections", &api::IntersectionBook::GetIntersections, py::return_value_policy::reference_internal)
+      .def("GetIntersection", &api::IntersectionBook::GetIntersection, py::arg("id"),
+           py::return_value_policy::reference_internal)
       .def("FindIntersection",
            py::overload_cast<const api::rules::TrafficLight::Id&>(&api::IntersectionBook::FindIntersection),
            py::arg("id"), py::return_value_policy::reference_internal)


### PR DESCRIPTION
# 🦟 Bug fix

### Summary

Missing `py::return_value_policy::reference_internal` statements was causing a segmentation fault when tearing down the context after execution.

