### PR TITLE
Adds binding for ToSegmentPosition.

### DIFF
--- a/src/bindings/api_py.cc
+++ b/src/bindings/api_py.cc
@@ -228,6 +228,7 @@ PYBIND11_MODULE(api, m) {
       .def("elevation_bounds", &api::Lane::elevation_bounds, py::arg("s"), py::arg("r"))
       .def("ToInertialPosition", &api::Lane::ToInertialPosition)
       .def("ToLanePosition", &api::Lane::ToLanePosition)
+      .def("ToSegmentPosition", &api::Lane::ToSegmentPosition)
       .def("GetOrientation", &api::Lane::GetOrientation)
       .def("EvalMotionDerivatives", &api::Lane::EvalMotionDerivatives, py::arg("lane_postion"), py::arg("velocity"))
       .def("GetBranchPoint", &api::Lane::GetBranchPoint, py::arg("which_end"))

--- a/test/api/api_test.py
+++ b/test/api/api_test.py
@@ -453,6 +453,7 @@ class TestMaliputApi(unittest.TestCase):
         self.assertTrue('elevation_bounds' in dut_type_methods)
         self.assertTrue('ToInertialPosition' in dut_type_methods)
         self.assertTrue('ToLanePosition' in dut_type_methods)
+        self.assertTrue('ToSegmentPosition' in dut_type_methods)
         self.assertTrue('EvalMotionDerivatives' in dut_type_methods)
         self.assertTrue('GetBranchPoint' in dut_type_methods)
         self.assertTrue('GetConfluentBranches' in dut_type_methods)


### PR DESCRIPTION
### Summary
Related to https://github.com/maliput/maliput/issues/496

- Adds binding to `Lane::ToSegmentPosition` method

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/1d978bb286dbf20cc5854826b118aadf/raw/69fbc1cfa9b0d91c05f84eb6018049ef2158ca29/maliput_py.repos