### PR TITLE
Adds LaneSRange::GetIntersection binding.

### DIFF
--- a/src/bindings/api_py.cc
+++ b/src/bindings/api_py.cc
@@ -256,7 +256,8 @@ PYBIND11_MODULE(api, m) {
       .def("lane_id", &api::LaneSRange::lane_id, py::return_value_policy::reference_internal)
       .def("s_range", &api::LaneSRange::s_range)
       .def("length", &api::LaneSRange::length)
-      .def("Intersects", &api::LaneSRange::Intersects, py::arg("lane_s_range"), py::arg("tolerance"));
+      .def("Intersects", &api::LaneSRange::Intersects, py::arg("lane_s_range"), py::arg("tolerance"))
+      .def("GetIntersection", &api::LaneSRange::GetIntersection, py::arg("lane_s_range"), py::arg("tolerance"));
 
   py::class_<api::LaneSRoute>(m, "LaneSRoute")
       .def(py::init<>())

--- a/test/api/api_test.py
+++ b/test/api/api_test.py
@@ -340,6 +340,16 @@ class TestMaliputApi(unittest.TestCase):
         self.assertTrue(dut.Intersects(overlapped_lane_s_range, TOLERANCE))
         not_overlapped_lane_s_range = LaneSRange(LaneId("dut_lane"), SRange(50., 75.))
         self.assertFalse(dut.Intersects(not_overlapped_lane_s_range, TOLERANCE))
+        # Check get_intersection methdo
+        non_intersected = dut.GetIntersection(other_lane_s_range, TOLERANCE)
+        self.assertEqual(non_intersected, None)
+        non_intersected = dut.GetIntersection(not_overlapped_lane_s_range, TOLERANCE)
+        self.assertEqual(non_intersected, None)
+        expected_intersection = LaneSRange(dut.lane_id(), SRange(10., 15.))
+        intersected = dut.GetIntersection(overlapped_lane_s_range, TOLERANCE)
+        self.assertEqual(intersected.lane_id(), expected_intersection.lane_id())
+        self.assertEqual(intersected.s_range().s0(), expected_intersection.s_range().s0())
+        self.assertEqual(intersected.s_range().s1(), expected_intersection.s_range().s1())
 
     def test_lane_s_route(self):
         """


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput/pull/542

## Summary
Adds binding for `LaneSRange::GetIntersection` method.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

