### PR TITLE
Adds missing Vector bindings.

### DIFF
--- a/src/bindings/math_py.cc
+++ b/src/bindings/math_py.cc
@@ -45,6 +45,10 @@ PYBIND11_MODULE(math, m) {
       .def("__getitem__", py::overload_cast<std::size_t>(&math::Vector3::operator[]), py::is_operator())
       .def("__eq__", [](const math::Vector3& a, const math::Vector3& b) { return a == b; })
       .def("__ne__", [](const math::Vector3& a, const math::Vector3& b) { return a != b; })
+      .def("__add__", [](const math::Vector3& a, const math::Vector3& b) { return a + b; })
+      .def("__sub__", [](const math::Vector3& a, const math::Vector3& b) { return a - b; })
+      .def("__mul__", [](const math::Vector3& a, double scalar) { return a * scalar; })
+      .def("__rmul__", [](const math::Vector3& a, double scalar) { return scalar * a; })
       .def("__str__",
            [](const math::Vector3& self) {
              std::stringstream ss;
@@ -52,6 +56,11 @@ PYBIND11_MODULE(math, m) {
              return ss.str();
            })
       .def("size", &math::Vector3::size)
+      .def("cross", &math::Vector3::cross)
+      .def("dot", [](const math::Vector3& self, const math::Vector3& other) { return self.dot(other); })
+      .def("norm", &math::Vector3::norm)
+      .def("normalize", &math::Vector3::normalize)
+      .def("normalized", &math::Vector3::normalized)
       .def("x", py::overload_cast<>(&math::Vector3::x))
       .def("y", py::overload_cast<>(&math::Vector3::y))
       .def("z", py::overload_cast<>(&math::Vector3::z));
@@ -61,6 +70,10 @@ PYBIND11_MODULE(math, m) {
       .def("__getitem__", py::overload_cast<std::size_t>(&math::Vector4::operator[]), py::is_operator())
       .def("__eq__", [](const math::Vector4& a, const math::Vector4& b) { return a == b; })
       .def("__ne__", [](const math::Vector4& a, const math::Vector4& b) { return a != b; })
+      .def("__add__", [](const math::Vector4& a, const math::Vector4& b) { return a + b; })
+      .def("__sub__", [](const math::Vector4& a, const math::Vector4& b) { return a - b; })
+      .def("__mul__", [](const math::Vector4& a, double scalar) { return a * scalar; })
+      .def("__rmul__", [](const math::Vector4& a, double scalar) { return scalar * a; })
       .def("__str__",
            [](const math::Vector4& self) {
              std::stringstream ss;
@@ -68,6 +81,10 @@ PYBIND11_MODULE(math, m) {
              return ss.str();
            })
       .def("size", &math::Vector4::size)
+      .def("dot", [](const math::Vector4& self, const math::Vector4& other) { return self.dot(other); })
+      .def("norm", &math::Vector4::norm)
+      .def("normalize", &math::Vector4::normalize)
+      .def("normalized", &math::Vector4::normalized)
       .def("x", py::overload_cast<>(&math::Vector4::x))
       .def("y", py::overload_cast<>(&math::Vector4::y))
       .def("z", py::overload_cast<>(&math::Vector4::z))

--- a/test/math/math_test.py
+++ b/test/math/math_test.py
@@ -61,7 +61,26 @@ class TestMaliputMath(unittest.TestCase):
         self.assertTrue(kDut[2] == 33.)
         self.assertTrue(kDut == Vector3(25., 158., 33.))
         self.assertTrue(kDut != Vector3(33., 158., 25.))
+        kDut2 = Vector3(kDut.x() * 2, kDut.y() * 2, kDut.z() * 2)
+        self.assertEqual(kDut + kDut, kDut2)
+        self.assertEqual(kDut2 - kDut, kDut)
+        self.assertEqual(2 * kDut, kDut2)
+        self.assertEqual(kDut * 2, kDut2)
         self.assertEqual(kDut.__str__(), "{25, 158, 33}")
+
+        kDut = Vector3(2., 3., 6.)
+        self.assertEqual(kDut.norm(), 7.)
+        kDutNormalized = Vector3(2. / 7., 3. / 7., 6. / 7.)
+        self.assertEqual(kDut.normalized(), kDutNormalized)
+        kDut.normalize()
+        self.assertEqual(kDut, kDutNormalized)
+
+        kDut = Vector3(3., 4., 5.)
+        self.assertEqual(kDut.dot(kDut), 50.)
+
+        left = Vector3(1., 2., 3.)
+        right = Vector3(4., 5., 6.)
+        self.assertEqual(left.cross(right), Vector3(-3., 6., -3.))
 
     def test_vector4(self):
         """
@@ -80,6 +99,22 @@ class TestMaliputMath(unittest.TestCase):
         self.assertTrue(kDut == Vector4(25., 158., 33., 0.02))
         self.assertTrue(kDut != Vector4(0.02, 33., 158., 25.))
         self.assertEqual(kDut.__str__(), "{25, 158, 33, 0.02}")
+        kDut2 = Vector4(kDut.x() * 2, kDut.y() * 2, kDut.z() * 2, kDut.w() * 2)
+        self.assertEqual(kDut + kDut, kDut2)
+        self.assertEqual(kDut2 - kDut, kDut)
+        self.assertEqual(2 * kDut, kDut2)
+        self.assertEqual(kDut * 2, kDut2)
+
+        kDut = Vector4(1., 2., 3., 4.)
+        kNorm = 5.477225575051661
+        self.assertEqual(kDut.norm(), kNorm)
+        kDutNormalized = Vector4(1. / kNorm, 2. / kNorm, 3. / kNorm, 4. / kNorm)
+        self.assertEqual(kDut.normalized(), kDutNormalized)
+        kDut.normalize()
+        self.assertEqual(kDut, kDutNormalized)
+
+        kDut = Vector4(3., 4., 5., 6.)
+        self.assertEqual(kDut.dot(kDut), 9. + 16. + 25. + 36.)
 
     def test_rollpitchyaw(self):
         """


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds missing bindings for the `maliput::math::Vector` interface

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
