### PR TITLE
Adds bindings for GenerateObjFile method.

### DIFF
--- a/src/bindings/CMakeLists.txt
+++ b/src/bindings/CMakeLists.txt
@@ -54,6 +54,22 @@ target_link_libraries(plugin_py
     pybind11::module
 )
 
+# utility module
+pybind11_add_module(utility_py utility_py.cc)
+
+set_target_properties(utility_py PROPERTIES OUTPUT_NAME "utility")
+
+target_include_directories(utility_py
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+)
+
+target_link_libraries(utility_py
+  PRIVATE
+    maliput::utility
+    pybind11::module
+)
+
 ##############################################################################
 # Install
 ##############################################################################
@@ -67,5 +83,9 @@ install(TARGETS math_py
 )
 
 install(TARGETS plugin_py
+  DESTINATION "${PYTHON_INSTALL_DIR}/maliput"
+)
+
+install(TARGETS utility_py
   DESTINATION "${PYTHON_INSTALL_DIR}/maliput"
 )

--- a/src/bindings/utility_py.cc
+++ b/src/bindings/utility_py.cc
@@ -1,0 +1,69 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven Planet. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include <string>
+
+#include <maliput/utility/generate_obj.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace maliput {
+namespace bindings {
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(utility, m) {
+  py::class_<utility::ObjFeatures>(m, "ObjFeatures")
+      .def(py::init<>())
+      .def_readwrite("max_grid_unit", &utility::ObjFeatures::max_grid_unit)
+      .def_readwrite("min_grid_resolution", &utility::ObjFeatures::min_grid_resolution)
+      .def_readwrite("draw_stripes", &utility::ObjFeatures::draw_stripes)
+      .def_readwrite("draw_arrows", &utility::ObjFeatures::draw_arrows)
+      .def_readwrite("draw_lane_haze", &utility::ObjFeatures::draw_lane_haze)
+      .def_readwrite("draw_branch_points", &utility::ObjFeatures::draw_branch_points)
+      .def_readwrite("draw_elevation_bounds", &utility::ObjFeatures::draw_elevation_bounds)
+      .def_readwrite("off_grid_mesh_generation", &utility::ObjFeatures::off_grid_mesh_generation)
+      .def_readwrite("simplify_mesh_threshold", &utility::ObjFeatures::simplify_mesh_threshold)
+      .def_readwrite("stripe_width", &utility::ObjFeatures::stripe_width)
+      .def_readwrite("stripe_elevation", &utility::ObjFeatures::stripe_elevation)
+      .def_readwrite("arrow_elevation", &utility::ObjFeatures::arrow_elevation)
+      .def_readwrite("lane_haze_elevation", &utility::ObjFeatures::lane_haze_elevation)
+      .def_readwrite("branch_point_elevation", &utility::ObjFeatures::branch_point_elevation)
+      .def_readwrite("branch_point_height", &utility::ObjFeatures::branch_point_height)
+      .def_readwrite("origin", &utility::ObjFeatures::origin)
+      .def_readwrite("highlighted_segments", &utility::ObjFeatures::highlighted_segments);
+
+  m.def("GenerateObjFile",
+        py::overload_cast<const api::RoadNetwork*, const std::string&, const std::string&, const utility::ObjFeatures&>(
+            &maliput::utility::GenerateObjFile),
+        "Generates a Wavefront OBJ model of the road surface of an maliput::api::RoadNetwork.", py::arg("road_network"),
+        py::arg("dirpath"), py::arg("fileroot"), py::arg("features"));
+}
+
+}  // namespace bindings
+}  // namespace maliput

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,3 +2,4 @@ find_package(ament_cmake_pytest REQUIRED)
 
 add_subdirectory(api)
 add_subdirectory(math)
+add_subdirectory(utility)

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -1,0 +1,9 @@
+# TODO(francocipollone): Improve this check by wrapping ament_add_pytest_test() function.
+# When sanitizers are activated python scripts are disabled.
+if (NOT ${SANITIZERS})
+  ament_add_pytest_test(utility_pytest
+    utility_test.py
+    # Avoid pytest from importing the module stub
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endif()

--- a/test/utility/utility_test.py
+++ b/test/utility/utility_test.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# BSD 3-Clause License
+#
+# Copyright (c) 2023, Woven Planet. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for the maliput::utility python binding"""
+
+import unittest
+
+
+from maliput.api import (
+    InertialPosition,
+)
+
+
+from maliput.utility import (
+    GenerateObjFile,
+    ObjFeatures
+)
+
+
+TOLERANCE = 1e-9
+
+
+class TestMaliputUtility(unittest.TestCase):
+    """
+    Evaluates the maliput.utility bindings for concrete classes or structs.
+    """
+
+    def test_generate_obj_file_method(self):
+        """
+        Tests that GenerateObjFile method exists.
+        """
+        dut_name = GenerateObjFile.__name__
+        self.assertEqual('GenerateObjFile', dut_name)
+
+    def test_obj_features(self):
+        """
+        Tests the ObjFeatures binding.
+        """
+        dut = ObjFeatures()
+
+        self.assertEqual(1.0, dut.max_grid_unit)
+        self.assertEqual(5.0, dut.min_grid_resolution)
+        self.assertEqual(True, dut.draw_stripes)
+        self.assertEqual(True, dut.draw_arrows)
+        self.assertEqual(True, dut.draw_lane_haze)
+        self.assertEqual(True, dut.draw_branch_points)
+        self.assertEqual(True, dut.draw_elevation_bounds)
+        self.assertEqual(False, dut.off_grid_mesh_generation)
+        self.assertEqual(0.0, dut.simplify_mesh_threshold)
+        self.assertEqual(0.25, dut.stripe_width)
+        self.assertEqual(0.05, dut.stripe_elevation)
+        self.assertEqual(0.05, dut.arrow_elevation)
+        self.assertEqual(0.02, dut.lane_haze_elevation)
+        self.assertEqual(0.5, dut.branch_point_elevation)
+        self.assertEqual(0.5, dut.branch_point_height)
+        self.assertEqual(InertialPosition(0., 0., 0.), dut.origin)
+        self.assertEqual([], dut.highlighted_segments)


### PR DESCRIPTION
# 🎉 New feature

#75 

## Summary
Adds bindings to utility methods related to generation of obj descriptions.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
